### PR TITLE
Update c-ares download URL in Dockerfile for proper installation

### DIFF
--- a/TargetMicroservices/socialNetwork/Dockerfile
+++ b/TargetMicroservices/socialNetwork/Dockerfile
@@ -59,7 +59,7 @@ RUN wget https://github.com/protocolbuffers/protobuf/archive/refs/tags/v25.1.tar
     && cmake --build . --target install -- -j`nproc`
 
 # Dependency needed by grpc
-RUN wget --no-check-certificate https://c-ares.org/download/c-ares-1.25.0.tar.gz \
+RUN wget https://github.com/c-ares/c-ares/releases/download/cares-1_25_0/c-ares-1.25.0.tar.gz \
     && tar zxf c-ares-1.25.0.tar.gz \
     && cd c-ares-1.25.0 \
     && cmake -DCMAKE_C_FLAGS='-fPIC' -DCMAKE_CXX_FLAGS='-fPIC -std=gnu++11' -DCMAKE_C_COMPILER=gcc-7 -DCMAKE_CXX_COMPILER=g++-7 \


### PR DESCRIPTION
This PR fixes an issue with the outdated c-ares download link in the following file: TargetMicroservices/socialNetwork/Dockerfile.

The previous download link for c-ares-1.25.0.tar.gz was resulting in a 404 Not Found error. The URL has been updated to the correct location from the official c-ares GitHub release:

Old URL:
https://c-ares.org/download/c-ares-1.25.0.tar.gz

New URL:
https://github.com/c-ares/c-ares/releases/download/cares-1_25_0/c-ares-1.25.0.tar.gz

Updating the link ensures that the Docker build process completes successfully and that the required c-ares dependency is installed without issues.